### PR TITLE
Bugfix return of status in BackendResponseStatus

### DIFF
--- a/src/Model/Common/BackendResponseStatus.php
+++ b/src/Model/Common/BackendResponseStatus.php
@@ -19,6 +19,6 @@ class BackendResponseStatus
 
     function getValue()
     {
-        return $status;
+        return $this->status;
     }
 }


### PR DESCRIPTION
No status returned because access of local instead of member variable.
