### PR TITLE
Use expressive 'yes' and 'no' for risk_suppress option

### DIFF
--- a/src/Request/AbstractPaymentRequest.php
+++ b/src/Request/AbstractPaymentRequest.php
@@ -251,7 +251,7 @@ class AbstractPaymentRequest extends AbstractWirecardRequest
      */
     function setRiskSuppress($value)
     {
-        return $this->addParam('riskSuppress', $value ? 1 : 0);
+        return $this->addParam('riskSuppress', $value ? 'yes' : 'no');
     }
 
     /**


### PR DESCRIPTION
Changed "1" and "0" for riskSuppress as flag to "yes" and "no" according to the documentation https://guides.wirecard.at/request_parameters?s[]=suppress#risksuppress