### PR TITLE
Added missing fingerprint params for RecurPaymentRequest in Seamless

### DIFF
--- a/src/Request/Seamless/Backend/RecurPaymentRequest.php
+++ b/src/Request/Seamless/Backend/RecurPaymentRequest.php
@@ -9,6 +9,7 @@ class RecurPaymentRequest extends AbstractBackendRequest
     protected $fingerprintOrder = [
         'orderNumber', 'sourceOrderNumber', 'autoDeposit', 'orderDescription',
         'amount', 'currency', 'orderReference', 'customerStatement',
+	    'mandateId', 'mandateSignatureDate', 'creditorId', 'dueDate', 'transactionIdentifier', 'useIbanBic'
     ];
     // protected $resultClass = 'Hochstrasser\Wirecard\Model\Seamless\Frontend\DataStorageInitResult';
 


### PR DESCRIPTION
I've noticed some params were missing when calculating fingerprint for recur payment request under seamless mode. When I added for example params like `transactionIdentifier`, or `useIbanBic`, response from wirecard is `"errorCode":"18506", "message":"REQUESTFINGERPRINT is invalid."`
After adding these params to fingerprint calculation, the error seems to be fixed.

I've added all the params listed in documentation here: https://guides.wirecard.at/back-end_operations:transaction-based:recurpayment